### PR TITLE
[FEARURE] 인기 여행지 도시(모든 나라 대상) 표시 / 유사도+인기도 기반 노출 API 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation 'com.ibm.icu:icu4j:74.1' // ISO 3166 country codes
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.apache.commons:commons-text:1.12.0' // LevenshteinDistance Algorithm
 }
 
 tasks.named('test') {

--- a/config/docker-compose-local.yml
+++ b/config/docker-compose-local.yml
@@ -5,10 +5,24 @@ services:
     container_name: redis_dev
     image: redis:7.2
     ports:
-      - "6380:6379"
+      - "6379:6379"
     volumes:
       - redis_data:/data
     restart: always
 
+  postgres:
+    container_name: postgres_dev
+    image: postgres:15
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: 1234
+      POSTGRES_DB: globber
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: always
+
 volumes:
   redis_data:
+  postgres_data:

--- a/diagram/class-favorite.puml
+++ b/diagram/class-favorite.puml
@@ -1,0 +1,37 @@
+@startuml
+class Member {
+  - id: Long
+  - email: String
+  - name: String
+  - password: String
+  - authProvider: AuthProvider
+  - roles: List<Role>
+}
+
+class RecommendedCityList {
+  - listId: Long
+  - cities: List<City>
+  + getCities(): List<City>
+}
+
+class City {
+  - cityId: Long
+  - cityName: String
+  - countryName: String
+  - flagIcon: String
+}
+
+class RedisCache {
+  + get(key: String): Object
+  + set(key: String, value: Object, ttl: long): void
+}
+
+class CityRepository {
+  + findRecommended(): RecommendedCityList
+}
+
+Member --> RecommendedCityList : 조회한다
+RecommendedCityList *-- City : 포함한다
+RecommendedCityList --> RedisCache : 캐싱된다
+RedisCache --> CityRepository : Miss 시 DB조회
+@enduml

--- a/diagram/class-search.puml
+++ b/diagram/class-search.puml
@@ -1,0 +1,39 @@
+@startuml
+class SearchService {
+    - CacheRepository cacheRepository
+    - CityRepository cityRepository
+    - RankingRepository rankingRepository
+    + List<String> search(String keyword)
+    + void select(String cityName)
+    + void recordSelection(String cityName)
+}
+
+interface CacheRepository {
+    + List<String> get(String key)
+    + void set(String key, List<String> value, int ttlMinutes)
+}
+
+interface CityRepository {
+    + List<City> searchByKeyword(String keyword)
+}
+
+interface RankingRepository {
+    + void incrementScore(String cityName)
+    + Map<String, Integer> getScores(List<String> cityNames)
+}
+
+class City {
+    - Long id
+    - String cityName
+    - String countryName
+}
+
+class User {
+}
+
+User --> SearchService : "검색 요청/선택"
+SearchService --> CacheRepository : "캐시 조회/저장"
+SearchService --> CityRepository : "DB 조회"
+SearchService --> RankingRepository : "점수 갱신/조회"
+CityRepository --> City : "엔티티 반환"
+@enduml

--- a/diagram/sequence-favorite.puml
+++ b/diagram/sequence-favorite.puml
@@ -1,0 +1,25 @@
+@startuml
+actor Member
+control UI
+control Service
+database DB as "내부 DB"
+collections RedisCache as "Redis 캐시"
+control Scheduler as "스케줄러"
+
+== 사용자 요청 흐름 ==
+Member -> UI : 인기 여행지 조회 요청
+UI -> Service : 인기 여행지 조회
+Service -> RedisCache : 캐시 조회 (key="recommended:city:list")
+alt 캐시에 데이터 있음
+    RedisCache --> Service : RecommendedCityList 반환
+else 캐시에 데이터 없음
+    Service -> DB : 인기 여행지 조회
+    DB --> Service : RecommendedCityList 반환
+    Service -> RedisCache : set(key, RecommendedCityList, ttl)
+end
+Service --> UI : RecommendedCityList 반환
+UI --> Member : 인기 여행지 화면 표시
+
+== 주기적 캐시 갱신 ==
+Scheduler -> DB : 인기 여행지 조회 (ex: 매 주 1번)
+@enduml

--- a/diagram/sequence-search.puml
+++ b/diagram/sequence-search.puml
@@ -1,0 +1,29 @@
+@startuml
+actor User
+control SearchService
+collections CacheRepository
+database CityRepository
+collections RankingRepository
+
+User -> SearchService : 검색 요청("인도")
+
+SearchService -> CacheRepository : GET "search:인도"
+alt 캐시 히트
+    CacheRepository --> SearchService : 결과 반환
+else 캐시 미스
+    CacheRepository --> SearchService : 없음
+    SearchService -> CityRepository : pg_bigm 기반 유사도 검색
+    CityRepository --> SearchService : 후보 리스트 ["인도","인도네시아","인도차이나"]
+
+    SearchService -> LevenshteinDistance : 알고리즘 기반 유사도 정렬
+
+    SearchService -> SearchService : 유사도 동점 시 인기순(점수)으로 정렬
+    SearchService -> CacheRepository : SET "search:인도" 결과, ttl=10분
+end
+
+SearchService --> User : 최종 결과 리스트
+
+== 최종 선택 반영 ==
+User -> SearchService : 최종 선택("인도네시아")
+SearchService -> RankingRepository : ZINCRBY "search_ranking" "인도네시아" 1
+@enduml

--- a/src/main/java/backend/globber/GlobberApplication.java
+++ b/src/main/java/backend/globber/GlobberApplication.java
@@ -2,8 +2,10 @@ package backend.globber;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @SpringBootApplication
+@EnableRedisRepositories(basePackages = "backend.globber.city.repository")
 public class GlobberApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/backend/globber/city/controller/CityController.java
+++ b/src/main/java/backend/globber/city/controller/CityController.java
@@ -1,0 +1,39 @@
+package backend.globber.city.controller;
+
+import backend.globber.city.controller.dto.RecommendResponse;
+import backend.globber.city.controller.dto.SearchResult;
+import backend.globber.city.service.CityService;
+import backend.globber.city.service.SearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/cities")
+@RequiredArgsConstructor
+@Tag(name = "도시 API", description = "도시 검색 및 인기 여행지 조회 API")
+public class CityController {
+
+    private final CityService cityService;
+    private final SearchService searchService;
+
+    @GetMapping("/favorites")
+    @Operation(summary = "인기 여행지 조회", description = "인기 여행지 목록을 조회합니다.")
+    public ResponseEntity<RecommendResponse> getFavorites() {
+        return ResponseEntity.ok(cityService.getRecommendedCities());
+    }
+
+    @GetMapping
+    @Operation(summary = "도시 검색", description = "키워드 기반으로 도시/국가를 검색합니다. 유사도 + 인기순 정렬")
+    public SearchResult search(@RequestParam String keyword) {
+        return searchService.search(keyword);
+    }
+
+    @PostMapping("/select")
+    public ResponseEntity<Void> selectCity(@RequestParam String cityName) {
+        searchService.recordSelection(cityName);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/backend/globber/city/controller/dto/CityResponse.java
+++ b/src/main/java/backend/globber/city/controller/dto/CityResponse.java
@@ -1,0 +1,16 @@
+package backend.globber.city.controller.dto;
+
+import backend.globber.city.domain.City;
+import lombok.Builder;
+
+@Builder
+public record CityResponse(Long cityId, String cityName, String countryName) {
+
+    public static CityResponse toResponse(City city) {
+        return CityResponse.builder()
+                .cityId(city.getCityId())
+                .cityName(city.getCityName())
+                .countryName(city.getCountryName())
+                .build();
+    }
+}

--- a/src/main/java/backend/globber/city/controller/dto/RecommendResponse.java
+++ b/src/main/java/backend/globber/city/controller/dto/RecommendResponse.java
@@ -1,0 +1,16 @@
+package backend.globber.city.controller.dto;
+
+import backend.globber.city.domain.City;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RecommendResponse(List<CityResponse> cityResponseList) {
+
+    public static RecommendResponse toResponse(List<City> city) {
+        return RecommendResponse.builder()
+                .cityResponseList(city.stream().map(CityResponse::toResponse).toList())
+                .build();
+    }
+}

--- a/src/main/java/backend/globber/city/controller/dto/SearchResponse.java
+++ b/src/main/java/backend/globber/city/controller/dto/SearchResponse.java
@@ -1,0 +1,8 @@
+package backend.globber.city.controller.dto;
+
+public record SearchResponse(
+        Long cityId,
+        String cityName,
+        String countryName) {
+}
+

--- a/src/main/java/backend/globber/city/controller/dto/SearchResult.java
+++ b/src/main/java/backend/globber/city/controller/dto/SearchResult.java
@@ -1,0 +1,6 @@
+package backend.globber.city.controller.dto;
+
+import java.util.List;
+
+public record SearchResult(List<SearchResponse> cities) {
+}

--- a/src/main/java/backend/globber/city/domain/City.java
+++ b/src/main/java/backend/globber/city/domain/City.java
@@ -1,0 +1,30 @@
+package backend.globber.city.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(
+        indexes = {
+                @Index(name = "idx_city_name", columnList = "cityName"),
+                @Index(name = "idx_country_name", columnList = "countryName"),
+                @Index(name = "idx_country_city", columnList = "countryName, cityName")
+        }
+)
+public class City {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long cityId;
+
+    @Column(nullable = false, length = 50)
+    private String cityName;
+
+    @Column(nullable = false, length = 50)
+    private String countryName;
+}

--- a/src/main/java/backend/globber/city/repository/CityRepository.java
+++ b/src/main/java/backend/globber/city/repository/CityRepository.java
@@ -1,0 +1,29 @@
+package backend.globber.city.repository;
+
+import backend.globber.city.controller.dto.SearchResponse;
+import backend.globber.city.domain.City;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CityRepository extends JpaRepository<City, Long> {
+
+    @Query("SELECT c FROM City c ORDER BY c.cityName ASC")
+    List<City> findRecommended();
+
+    /**
+     * pg_bigm 후보군 추출 (상위 300개)
+     */
+    @Query(value = """
+            SELECT c.city_id   AS cityId,
+                   c.city_name AS cityName,
+                   c.country_name AS countryName
+            FROM city c
+            WHERE c.city_name ILIKE '%' || :keyword || '%'
+               OR c.country_name ILIKE '%' || :keyword || '%'
+            LIMIT 300
+            """, nativeQuery = true)
+    List<SearchResponse> findCandidates(@Param("keyword") String keyword);
+}

--- a/src/main/java/backend/globber/city/repository/cache/CacheRepository.java
+++ b/src/main/java/backend/globber/city/repository/cache/CacheRepository.java
@@ -1,0 +1,27 @@
+package backend.globber.city.repository.cache;
+
+import backend.globber.city.controller.dto.SearchResult;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+public class CacheRepository {
+
+    private final RedisTemplate<String, SearchResult> redisTemplate;
+
+    public CacheRepository(
+            @Qualifier("redisTemplate2") RedisTemplate<String, SearchResult> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public SearchResult get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void set(String key, SearchResult value, int ttlMinutes) {
+        redisTemplate.opsForValue().set(key, value, ttlMinutes, TimeUnit.MINUTES);
+    }
+}

--- a/src/main/java/backend/globber/city/repository/cache/RankingRepository.java
+++ b/src/main/java/backend/globber/city/repository/cache/RankingRepository.java
@@ -1,0 +1,40 @@
+package backend.globber.city.repository.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String RANKING_KEY = "search_ranking";
+
+    /**
+     * 특정 키워드의 점수를 1 증가시킴
+     */
+    public void incrementScore(String keyword) {
+        redisTemplate.opsForZSet().incrementScore(RANKING_KEY, keyword, 1);
+    }
+
+    public Double getScore(String keyword) {
+        return redisTemplate.opsForZSet().score(RANKING_KEY, keyword);
+    }
+
+    /**
+     * 여러 키워드의 점수를 한 번에 조회
+     */
+    public Map<String, Double> getScores(List<String> keywords) {
+        Map<String, Double> scores = new HashMap<>();
+        for (String keyword : keywords) {
+            Double score = redisTemplate.opsForZSet().score(RANKING_KEY, keyword);
+            scores.put(keyword, score != null ? score : 0.0);
+        }
+        return scores;
+    }
+}

--- a/src/main/java/backend/globber/city/repository/cache/RecommendedCityListRepository.java
+++ b/src/main/java/backend/globber/city/repository/cache/RecommendedCityListRepository.java
@@ -1,0 +1,31 @@
+package backend.globber.city.repository.cache;
+
+import backend.globber.city.controller.dto.RecommendResponse;
+import backend.globber.city.domain.City;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendedCityListRepository {
+
+    @Qualifier("redisTemplate3")
+    private final RedisTemplate<String, RecommendResponse> redisTemplate;
+
+    private static final long TTL = 30; // 30일
+
+    public void saveRecommendedCities(String key, List<City> cities) {
+        RecommendResponse list = RecommendResponse.toResponse(cities);
+        redisTemplate.opsForValue().set(key, list, TTL, TimeUnit.DAYS);
+    }
+
+    public RecommendResponse getRecommendedCities(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+}
+

--- a/src/main/java/backend/globber/city/service/CityService.java
+++ b/src/main/java/backend/globber/city/service/CityService.java
@@ -1,0 +1,33 @@
+package backend.globber.city.service;
+
+import backend.globber.city.controller.dto.RecommendResponse;
+import backend.globber.city.domain.City;
+import backend.globber.city.repository.CityRepository;
+import backend.globber.city.repository.cache.RecommendedCityListRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CityService {
+
+    private final CityRepository cityRepository;
+    private final RecommendedCityListRepository recommendedCityListRepository;
+
+    private static final String KEY = "recommended:city:list";
+
+    public RecommendResponse getRecommendedCities() {
+        RecommendResponse cached = recommendedCityListRepository.getRecommendedCities(KEY);
+        if (cached != null) {
+            return cached;
+        }
+
+        List<City> cities = cityRepository.findRecommended();
+
+        recommendedCityListRepository.saveRecommendedCities(KEY, cities);
+
+        return RecommendResponse.toResponse(cities);
+    }
+}

--- a/src/main/java/backend/globber/city/service/SearchService.java
+++ b/src/main/java/backend/globber/city/service/SearchService.java
@@ -1,0 +1,84 @@
+package backend.globber.city.service;
+
+import backend.globber.city.controller.dto.SearchResponse;
+import backend.globber.city.controller.dto.SearchResult;
+import backend.globber.city.repository.CityRepository;
+import backend.globber.city.repository.cache.CacheRepository;
+import backend.globber.city.repository.cache.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final CacheRepository cacheRepository;
+    private final RankingRepository rankingRepository;
+    private final CityRepository cityRepository;
+
+    public SearchResult search(String keyword) {
+        String cacheKey = "search:" + keyword;
+
+        SearchResult cached = cacheRepository.get(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+
+        List<SearchResponse> candidates = cityRepository.findCandidates(keyword);
+
+        Map<String, Double> scores = rankingRepository.getScores(
+                candidates.stream().map(SearchResponse::cityName).toList()
+        );
+
+        LevenshteinDistance levenshtein = new LevenshteinDistance();
+
+        List<SearchResponse> sorted = candidates.stream()
+                .sorted(
+                        Comparator
+                                .comparingInt((SearchResponse c) -> exactMatchRank(c, keyword))
+                                .thenComparingInt(c -> similarityRank(c, keyword, levenshtein))
+                                .thenComparing(
+                                        Comparator.comparingDouble((SearchResponse c) -> popularityRank(c, scores))
+                                                .reversed()
+                                )
+                )
+                .limit(100)
+                .toList();
+
+        SearchResult result = new SearchResult(sorted);
+        cacheRepository.set(cacheKey, result, 10);
+
+        return result;
+    }
+
+    public void recordSelection(String cityName) {
+        rankingRepository.incrementScore(cityName);
+    }
+
+    private int exactMatchRank(SearchResponse c, String keyword) {
+        if (c.cityName().equals(keyword) || c.countryName().equals(keyword)) {
+            return 0;
+        }
+        return 1;
+    }
+
+    private int similarityRank(SearchResponse c, String keyword, LevenshteinDistance levenshtein) {
+        if (c.cityName().equals(keyword) || c.countryName().equals(keyword)) {
+            return 0;
+        }
+        return levenshtein.apply(c.cityName(), keyword);
+    }
+
+    private double popularityRank(SearchResponse c, Map<String, Double> scores) {
+        if (scores.containsKey(c.cityName())) {
+            return scores.get(c.cityName());
+        }
+        return 0.0;
+    }
+}
+

--- a/src/main/java/backend/globber/config/RedisConfig.java
+++ b/src/main/java/backend/globber/config/RedisConfig.java
@@ -2,10 +2,13 @@ package backend.globber.config;
 
 
 import backend.globber.auth.domain.RefreshToken;
+import backend.globber.city.controller.dto.RecommendResponse;
+import backend.globber.city.controller.dto.SearchResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
@@ -33,6 +36,17 @@ public class RedisConfig {
             LettuceClientConfiguration.defaultConfiguration());
     }
 
+    // 범용 레디스 설정
+    @Bean
+    @Primary
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory1());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        return template;
+    }
+
     // 레디스 데이터 템플릿 설정, Refresh 토큰 저장용으로 String : Object(RedisToken) 형식으로 설정
     @Bean(name = "redisTemplate1")
     public RedisTemplate<String, RefreshToken> redisTemplate1() {
@@ -44,4 +58,21 @@ public class RedisConfig {
         return redisTemplate;
     }
 
+    @Bean(name = "redisTemplate2")
+    public RedisTemplate<String, SearchResult> redisTemplate2() {
+        RedisTemplate<String, SearchResult> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory1());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(SearchResult.class));
+        return template;
+    }
+
+    @Bean(name = "redisTemplate3")
+    public RedisTemplate<String, RecommendResponse> redisTemplate3() {
+        RedisTemplate<String, RecommendResponse> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory1());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(RecommendResponse.class));
+        return template;
+    }
 }

--- a/src/main/java/backend/globber/config/SwaggerConfig.java
+++ b/src/main/java/backend/globber/config/SwaggerConfig.java
@@ -23,7 +23,7 @@ public class SwaggerConfig {
     // 그룹화된 API 생성
     public GroupedOpenApi api() {
         String[] paths = {"/**"};
-        String[] packagesToScan = {"backend.globber.controller"};
+        String[] packagesToScan = {"backend.globber"};
         return GroupedOpenApi.builder()
             .group("GLOBBER API")
             .pathsToMatch(paths)

--- a/src/test/java/backend/globber/city/service/CityServiceIntegrationTest.java
+++ b/src/test/java/backend/globber/city/service/CityServiceIntegrationTest.java
@@ -1,0 +1,84 @@
+package backend.globber.city.service;
+
+import backend.globber.city.controller.dto.RecommendResponse;
+import backend.globber.city.domain.City;
+import backend.globber.city.repository.CityRepository;
+import backend.globber.city.repository.cache.RecommendedCityListRepository;
+import backend.globber.support.PostgresTestConfig;
+import backend.globber.support.RedisTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Import({RedisTestConfig.class, PostgresTestConfig.class})
+class CityServiceIntegrationTest {
+
+    @Autowired
+    private CityRepository cityRepository;
+
+    @Autowired
+    private RecommendedCityListRepository recommendedCityListRepository;
+
+    @Autowired
+    private CityService cityService;
+
+    @BeforeEach
+    void setUp() {
+        // DB에 20개 City 데이터 삽입
+        List<City> cities = IntStream.rangeClosed(1, 20)
+                .mapToObj(i -> {
+                    City c = new City();
+                    try {
+                        var cityNameField = City.class.getDeclaredField("cityName");
+                        cityNameField.setAccessible(true);
+                        cityNameField.set(c, "City" + i);
+
+                        var countryField = City.class.getDeclaredField("countryName");
+                        countryField.setAccessible(true);
+                        countryField.set(c, "Country" + i);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                    return c;
+                }).toList();
+        cityRepository.saveAll(cities);
+    }
+
+    @Test
+    @DisplayName("캐시에 없으면 DB에서 조회 후 Redis에 저장된다")
+    void testCacheMiss() {
+        // when
+        RecommendResponse result = cityService.getRecommendedCities();
+
+        // then
+        assertThat(result.cityResponseList()).hasSize(20);
+
+        // Redis에 데이터 저장되었는지 확인
+        RecommendResponse cached = recommendedCityListRepository.getRecommendedCities("recommended:city:list");
+        assertThat(cached.cityResponseList()).hasSize(20);
+    }
+
+    @Test
+    @DisplayName("캐시에 있으면 DB를 조회하지 않고 Redis에서 조회한다")
+    void testCacheHit() {
+        // given: 첫 번째 호출로 캐시 저장
+        cityService.getRecommendedCities();
+
+        // when: 두 번째 호출
+        RecommendResponse result = cityService.getRecommendedCities();
+
+        // then
+        assertThat(result.cityResponseList()).hasSize(20);
+        RecommendResponse cached = recommendedCityListRepository.getRecommendedCities("recommended:city:list");
+        assertThat(cached.cityResponseList()).hasSize(20);
+    }
+}

--- a/src/test/java/backend/globber/city/service/SearchServiceIntegrationTest.java
+++ b/src/test/java/backend/globber/city/service/SearchServiceIntegrationTest.java
@@ -1,0 +1,176 @@
+package backend.globber.city.service;
+
+import backend.globber.city.controller.dto.SearchResponse;
+import backend.globber.city.controller.dto.SearchResult;
+import backend.globber.city.domain.City;
+import backend.globber.city.repository.CityRepository;
+import backend.globber.city.repository.cache.RankingRepository;
+import backend.globber.support.PostgresTestConfig;
+import backend.globber.support.RedisTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Import({PostgresTestConfig.class, RedisTestConfig.class})
+class SearchServiceIntegrationTest {
+
+    @Autowired
+    private SearchService searchService;
+
+    @Autowired
+    private CityRepository cityRepository;
+
+    @Autowired
+    private RankingRepository rankingRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute("CREATE EXTENSION IF NOT EXISTS pg_bigm");
+        jdbcTemplate.execute("CREATE INDEX IF NOT EXISTS idx_city_name_bigm ON city USING gin (city_name gin_bigm_ops)");
+        jdbcTemplate.execute("CREATE INDEX IF NOT EXISTS idx_country_name_bigm ON city USING gin (country_name gin_bigm_ops)");
+
+        cityRepository.deleteAll();
+        cityRepository.saveAll(List.of(
+                new City(null, "뉴델리", "인도"),
+                new City(null, "타지마할", "인도"),
+                new City(null, "민우", "인도"),
+                new City(null, "서울", "대한민국"),
+                new City(null, "인천", "대한민국"),
+                new City(null, "부산", "대한민국"),
+                new City(null, "베이징", "중국"),
+                new City(null, "상하이", "중국"),
+                new City(null, "홍콩", "중국"),
+                new City(null, "도쿄", "일본"),
+                new City(null, "오사카", "일본")
+        ));
+    }
+
+    @Test
+    @DisplayName("pg_bigm 인덱스가 생성되어 있다")
+    void testPgBigmIndexExists() {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_city_name_bigm'",
+                Integer.class
+        );
+
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("검색 결과는 캐시에 저장되어 이후 캐시 히트 시 DB를 조회하지 않는다")
+    void testSearchCacheHit() {
+        // given
+        searchService.search("일본");
+
+        // when
+        SearchResult cachedResult = searchService.search("일본");
+
+        // then
+        assertThat(cachedResult.cities()).hasSize(2); // 도쿄, 오사카
+    }
+
+    @Test
+    @DisplayName("최종 선택이 반영되면 랭킹 점수가 증가한다")
+    void testRecordSelection() {
+        // given
+        searchService.recordSelection("뉴델리");
+
+        // when
+        Double score = rankingRepository.getScore("뉴델리");
+
+        // then
+        assertThat(score).isNotNull();
+        assertThat(score).isGreaterThan(0.0);
+    }
+
+    @Test
+    @DisplayName("검색어 '인도' 입력 시 유사도가 높은 도시가 나온다 (뉴델리, 뭄바이)")
+    void testSimilarityRankingMultipleCities() {
+        // when
+        SearchResult result = searchService.search("인도");
+
+        // then
+        List<String> names = result.cities().stream()
+                .map(SearchResponse::cityName)
+                .toList();
+
+        System.out.println(names);
+        assertThat(names).contains("뉴델리", "민우", "타지마할");
+
+    }
+
+    @Test
+    @DisplayName("인기도 점수가 높은 도시는 유사도가 같을 경우 더 앞에 정렬된다 (뉴델리 vs 뭄바이)")
+    void testPopularityRankingWithMultipleCities() {
+        // given
+        searchService.recordSelection("뭄바이");
+        searchService.recordSelection("뭄바이");
+        searchService.recordSelection("뭄바이");
+
+        // when
+        SearchResult result = searchService.search("인도");
+
+        // then
+        List<String> names = result.cities().stream()
+                .map(SearchResponse::cityName)
+                .toList();
+
+        // 뭄바이 인기도 점수를 올렸으므로 뉴델리보다 앞에 와야 함
+        assertThat(names.indexOf("뭄바이"))
+                .isLessThan(names.indexOf("뉴델리"));
+
+        assertThat(names.indexOf("뭄바이"))
+                .isLessThan(names.indexOf("뉴델리"));
+    }
+
+    @Test
+    @DisplayName("인기도 점수가 높은 도시는 유사도가 같을 경우 더 앞에 정렬된다 2 (서울 vs 부산 vs 인천)")
+    void testPopularityRankingWithMultipleCities2() {
+        // given
+        searchService.recordSelection("서울");
+        searchService.recordSelection("서울");
+        searchService.recordSelection("서울");
+
+        // when
+        SearchResult result = searchService.search("대한민국");
+
+        // then
+        List<String> names = result.cities().stream()
+                .map(SearchResponse::cityName)
+                .toList();
+
+        assertThat(names.indexOf("서울"))
+                .isLessThan(names.indexOf("부산"));
+
+        assertThat(names.indexOf("서울"))
+                .isLessThan(names.indexOf("인천"));
+    }
+
+    @Test
+    @DisplayName("검색 결과는 최대 100개까지만 반환된다")
+    void testResultLimit() {
+        // given
+        for (int i = 0; i < 200; i++) {
+            cityRepository.save(new City(null, "테스트도시" + i, "테스트국가"));
+        }
+
+        // when
+        SearchResult result = searchService.search("테스트");
+
+        // then
+        assertThat(result.cities().size()).isLessThanOrEqualTo(100);
+    }
+}

--- a/src/test/java/backend/globber/support/RedisTestConfig.java
+++ b/src/test/java/backend/globber/support/RedisTestConfig.java
@@ -2,8 +2,10 @@ package backend.globber.support;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
@@ -27,6 +29,7 @@ public class RedisTestConfig {
     }
 
     @Bean
+    @Primary
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(
                 redisContainer.getHost(),

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS city (
+                                    city_id SERIAL PRIMARY KEY,
+                                    city_name TEXT NOT NULL,
+                                    country_name TEXT NOT NULL
+);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #9 
closes #8

## 📝 작업 내용
- 인기 여행지 도시(모든 나라 대상) 표시 API
- 유사도+인기도 기반 노출 API 

### [인기 여행지 도시(모든 나라 대상) 표시 API 시퀀스 다이어그램]
## ***📸 스크린샷***
<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/4a266d49-e4d6-4d5f-86c3-9f0759c7d24a" />

### [인기 여행지 도시(모든 나라 대상) 표시 API 클래스 다이어그램]
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/16f3ee27-89b4-449c-a423-6233d86a2386" />

### [유사도+인기도 기반 노출 API 시퀀스 다이어그램]
<img width="700" height="635" alt="image" src="https://github.com/user-attachments/assets/4a63f2d2-d8b4-4854-9a07-524d379d7329" />

### [유사도+인기도 기반 노출 API 클래스 다이어그램]
<img width="700" height="500" alt="image" src="https://github.com/user-attachments/assets/c8b8f9a4-d32d-408d-8958-35f4af1c0dda" />

---

### [유사도+인기도 기반 노출 API]
## 변경 내용

1. **검색 정렬 로직 개선 (`SearchService`)**

   * 1순위: `cityName` 또는 `countryName`이 **키워드와 정확히 일치**하는 경우 우선 정렬
   * 2순위: **레벤슈타인 거리 기반 유사도**
   * 3순위: **인기도 점수(popularity score)** 반영
   * 결과는 최대 100개까지만 반환

2. **pg\_bigm 기반 후보군 조회 (`CityRepository.findCandidates`)**

   * 부분 문자열 검색 시 `pg_bigm` 인덱스를 활용할 수 있도록 GIN 인덱스 추가
   * 후보군은 상위 300개까지만 조회

   ```sql
   CREATE EXTENSION IF NOT EXISTS pg_bigm;
   CREATE INDEX IF NOT EXISTS idx_city_name_bigm
       ON city USING gin (city_name gin_bigm_ops);
   CREATE INDEX IF NOT EXISTS idx_country_name_bigm
       ON city USING gin (country_name gin_bigm_ops);
   ```

3. **통합 테스트 추가 (`SearchServiceIntegrationTest`)**

   * `pg_bigm` 인덱스 정상 생성 여부 검증
   * 캐싱 동작 확인 (DB 조회 vs 캐시 히트)
   * 인기도 점수 정렬 반영 검증
   * 검색 결과 개수 제한 검증

---

## 도입 이유

* 기존 단순 유사도 기반 검색 → **정확한 검색 결과 보장 어려움**
* 입력 키워드와 **정확히 일치하는 도시/국가 우선 노출** 필요
* 전 세계 도시 데이터 (수천\~수만 건 이상) 검색 시 `LIKE '%keyword%'`의 성능 한계
* `pg_bigm` 인덱스를 통해 **부분 문자열 검색 성능 최적화**
* 캐시 및 인기 점수 반영으로 **사용자 경험 개선**

---

## 인기 여행지 조회 API 

### 1. 주요 컴포넌트

- **Member (사용자)**
  - 웹/앱 화면(UI)을 통해 인기 여행지 정보를 요청하는 주체입니다.

- **UI (화면 계층)**
  - 사용자의 요청을 Service 계층에 전달하고, 최종 응답을 사용자에게 보여줍니다.

- **Service (서비스 계층)**
  - 비즈니스 로직을 담당하는 핵심 계층입니다.
  - 캐시 조회 → DB 조회 → 캐시 저장 과정을 수행합니다.

- **DB (내부 DB)**
  - 실제 인기 여행지 데이터를 보관하는 저장소입니다.

- **Redis 캐시**
  - 반복 조회 시 성능 향상을 위해 DB에서 가져온 데이터를 저장합니다.
  - `key="recommended:city:list"` 형태로 인기 여행지 리스트를 캐싱합니다.

---

### 2. 사용자 요청 흐름

1. **사용자가 UI에 요청**
   - Member가 UI를 통해 "인기 여행지 조회"를 요청합니다.

2. **Service에서 캐시 조회**
   - Service는 Redis 캐시(`recommended:city:list`)를 먼저 확인합니다.

3. **캐시 히트(Cache Hit)**
   - 캐시에 데이터가 있다면 Redis에서 즉시 가져와 반환합니다.

4. **캐시 미스(Cache Miss)**
   - 캐시에 데이터가 없다면 DB에서 인기 여행지 리스트를 조회합니다.
   - 조회된 결과를 Redis 캐시에 저장(`set(key, value, ttl)`)합니다.

5. **응답 반환**
   - Service는 최종 RecommendedCityList를 UI에 반환하고, UI는 화면에 출력합니다.

---



