### PR TITLE
[FEAT] 응답 형식에 나라 코드 추가

### DIFF
--- a/src/main/java/backend/globber/city/controller/dto/CityResponse.java
+++ b/src/main/java/backend/globber/city/controller/dto/CityResponse.java
@@ -4,13 +4,17 @@ import backend.globber.city.domain.City;
 import lombok.Builder;
 
 @Builder
-public record CityResponse(Long cityId, String cityName, String countryName) {
+public record CityResponse(Long cityId, String cityName, String countryName, Double lat, Double lng,
+                           String countryCode) {
 
     public static CityResponse toResponse(final City city) {
         return CityResponse.builder()
                 .cityId(city.getCityId())
                 .cityName(city.getCityName())
                 .countryName(city.getCountryName())
+                .lat(city.getLat())
+                .lng(city.getLng())
+                .countryCode(city.getCountryCode())
                 .build();
     }
 }

--- a/src/main/java/backend/globber/city/controller/dto/SearchResponse.java
+++ b/src/main/java/backend/globber/city/controller/dto/SearchResponse.java
@@ -7,13 +7,19 @@ import lombok.Builder;
 public record SearchResponse(
         Long cityId,
         String cityName,
-        String countryName) {
+        String countryName,
+        Double lat,
+        Double lng,
+        String countryCode) {
 
     public static City toEntity(final SearchResponse searchResponse) {
         return City.builder()
                 .cityId(searchResponse.cityId)
                 .cityName(searchResponse.cityName)
                 .countryName(searchResponse.countryName)
+                .lat(searchResponse.lat)
+                .lng(searchResponse.lng)
+                .countryCode(searchResponse.countryCode)
                 .build();
     }
 }

--- a/src/main/java/backend/globber/city/domain/City.java
+++ b/src/main/java/backend/globber/city/domain/City.java
@@ -16,9 +16,14 @@ import lombok.NoArgsConstructor;
                 @Index(name = "idx_city_name", columnList = "cityName"),
                 @Index(name = "idx_country_name", columnList = "countryName"),
                 @Index(name = "idx_country_city", columnList = "countryName, cityName")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_country_code_city",
+                        columnNames = {"countryCode", "cityName"}
+                )
         }
 )
-// 확실해지기 전에는 빌더 필요
 @Builder
 public class City {
 

--- a/src/main/java/backend/globber/city/repository/CityRepository.java
+++ b/src/main/java/backend/globber/city/repository/CityRepository.java
@@ -23,7 +23,10 @@ public interface CityRepository extends JpaRepository<City, Long> {
     @Query(value = """
             SELECT c.city_id   AS cityId,
                    c.city_name AS cityName,
-                   c.country_name AS countryName
+                   c.country_name AS countryName,
+                   c.lat AS lat,
+                   c.lng AS lng,
+                   c.country_code AS countryCode
             FROM city c
             WHERE c.city_name ILIKE '%' || :keyword || '%'
                OR c.country_name ILIKE '%' || :keyword || '%'

--- a/src/test/java/backend/globber/city/service/CityServiceIntegrationTest.java
+++ b/src/test/java/backend/globber/city/service/CityServiceIntegrationTest.java
@@ -39,9 +39,7 @@ class CityServiceIntegrationTest {
     @Test
     @DisplayName("인기 도시 조회 시 limit 개수만큼 반환된다")
     void getTopCities_limitTest() {
-        List<City> cities = IntStream.rangeClosed(1, 50)
-                .mapToObj(i -> new City(null, "City" + i, "Country" + i, 123.12, 123.12, "KOR"))
-                .toList();
+        List<City> cities = IntStream.rangeClosed(1, 50).mapToObj(i -> new City(null, "City" + i, "Country" + i, 123.12, 123.12, "KOR")).toList();
         cityRepository.saveAll(cities);
         cities.forEach(rankingRepository::incrementScore);
 
@@ -56,9 +54,7 @@ class CityServiceIntegrationTest {
     @Test
     @DisplayName("Redis에 데이터가 없으면 DB에서 limit 개수 조회한다")
     void getTopCities_fallbackToDb() {
-        List<City> cities = IntStream.rangeClosed(1, 50)
-                .mapToObj(i -> new City(null, "City" + i, "Country" + i, 123.12, 123.12, "KOR"))
-                .toList();
+        List<City> cities = IntStream.rangeClosed(1, 50).mapToObj(i -> new City(null, "City" + i, "Country" + i, 123.12, 123.12, "KOR")).toList();
         cityRepository.saveAll(cities);
 
         int limit = 5;
@@ -72,15 +68,7 @@ class CityServiceIntegrationTest {
     @DisplayName("Redis에 데이터가 없으면 DB에서 limit 개수 조회한다 (모든 필드 검증)")
     void getTopCities_fallbackToDb_fullFields() {
         // given
-        List<City> cities = IntStream.rangeClosed(1, 5)
-                .mapToObj(i -> City.builder()
-                        .cityId(null)
-                        .cityName("City" + i)
-                        .countryName("Country" + i)
-                        .lat(123.12)
-                        .lng(456.78)
-                        .countryCode("KOR").build())
-                .toList();
+        List<City> cities = IntStream.rangeClosed(1, 5).mapToObj(i -> City.builder().cityId(null).cityName("City" + i).countryName("Country" + i).lat(123.12).lng(456.78).countryCode("KOR").build()).toList();
         cityRepository.saveAll(cities);
 
 
@@ -92,15 +80,15 @@ class CityServiceIntegrationTest {
         // then
         assertThat(response.cityResponseList()).hasSize(limit);
 
-        IntStream.range(0, limit).forEach(i -> {
-            CityResponse dto = response.cityResponseList().get(i);
-            City expected = cities.get(i);
+        var expectedNames = cities.stream().map(City::getCityName).toList();
+        var expectedCountries = cities.stream().map(City::getCountryName).toList();
 
-            assertThat(dto.cityName()).isEqualTo(expected.getCityName());
-            assertThat(dto.countryName()).isEqualTo(expected.getCountryName());
-            assertThat(dto.lat()).isEqualTo(expected.getLat());
-            assertThat(dto.lng()).isEqualTo(expected.getLng());
-            assertThat(dto.countryCode()).isEqualTo(expected.getCountryCode());
+        assertThat(response.cityResponseList().stream().map(CityResponse::cityName)).containsExactlyInAnyOrderElementsOf(expectedNames);
+        assertThat(response.cityResponseList().stream().map(CityResponse::countryName)).containsExactlyInAnyOrderElementsOf(expectedCountries);
+        assertThat(response.cityResponseList()).allSatisfy(dto -> {
+            assertThat(dto.lat()).isEqualTo(123.12);
+            assertThat(dto.lng()).isEqualTo(456.78);
+            assertThat(dto.countryCode()).isEqualTo("KOR");
         });
     }
 

--- a/src/test/java/backend/globber/city/service/CityServiceIntegrationTest.java
+++ b/src/test/java/backend/globber/city/service/CityServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package backend.globber.city.service;
 
+import backend.globber.city.controller.dto.CityResponse;
 import backend.globber.city.controller.dto.RecommendResponse;
 import backend.globber.city.domain.City;
 import backend.globber.city.repository.CityRepository;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.IntStream;
@@ -21,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 @ContextConfiguration(initializers = RedisTestConfig.Initializer.class)
 @Import({PostgresTestConfig.class, RedisTestConfig.class})
+@Transactional
 class CityServiceIntegrationTest {
 
     @Autowired
@@ -64,4 +67,41 @@ class CityServiceIntegrationTest {
 
         assertThat(response.cityResponseList()).hasSize(limit);
     }
+
+    @Test
+    @DisplayName("Redis에 데이터가 없으면 DB에서 limit 개수 조회한다 (모든 필드 검증)")
+    void getTopCities_fallbackToDb_fullFields() {
+        // given
+        List<City> cities = IntStream.rangeClosed(1, 5)
+                .mapToObj(i -> City.builder()
+                        .cityId(null)
+                        .cityName("City" + i)
+                        .countryName("Country" + i)
+                        .lat(123.12)
+                        .lng(456.78)
+                        .countryCode("KOR").build())
+                .toList();
+        cityRepository.saveAll(cities);
+
+
+        int limit = 5;
+
+        // when
+        RecommendResponse response = cityService.getTopCities(limit);
+
+        // then
+        assertThat(response.cityResponseList()).hasSize(limit);
+
+        IntStream.range(0, limit).forEach(i -> {
+            CityResponse dto = response.cityResponseList().get(i);
+            City expected = cities.get(i);
+
+            assertThat(dto.cityName()).isEqualTo(expected.getCityName());
+            assertThat(dto.countryName()).isEqualTo(expected.getCountryName());
+            assertThat(dto.lat()).isEqualTo(expected.getLat());
+            assertThat(dto.lng()).isEqualTo(expected.getLng());
+            assertThat(dto.countryCode()).isEqualTo(expected.getCountryCode());
+        });
+    }
+
 }

--- a/src/test/java/backend/globber/city/service/SearchServiceIntegrationTest.java
+++ b/src/test/java/backend/globber/city/service/SearchServiceIntegrationTest.java
@@ -237,5 +237,20 @@ class SearchServiceIntegrationTest {
         assertThat(names.get(2)).isEqualTo("City20");
     }
 
+    @Test
+    @DisplayName("뉴델리 데이터가 정확히 저장되고 조회된다")
+    void searchDataSuccess() {
+        // when
+        SearchResult result = searchService.search("뉴델리");
 
+        // then
+        assertThat(result.cities())
+                .anySatisfy(city -> {
+                    assertThat(city.cityName()).isEqualTo("뉴델리");
+                    assertThat(city.countryName()).isEqualTo("인도");
+                    assertThat(city.lat()).isEqualTo(28.6139);
+                    assertThat(city.lng()).isEqualTo(77.2090);
+                    assertThat(city.countryCode()).isEqualTo("IND");
+                });
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #26 


## 📝 작업 내용
1. 응답 형식에 나라 코드 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 도시 및 검색 결과에 위도(lat), 경도(lng), 국가코드(countryCode) 정보가 추가로 표시됩니다.
- Chores
  - 검색 결과를 최대 300개로 제한하여 응답 안정성과 일관성을 개선했습니다.
  - 내부 구성 요소 버전을 갱신했습니다.
- Tests
  - 도시 목록 및 검색 결과에 새 필드(위도·경도·국가코드)가 정확히 포함되는지 검증하는 통합 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->