### PR TITLE
[REFACTOR] 네이밍 변경

### DIFF
--- a/src/main/java/backend/globber/membertravel/controller/GlobeController.java
+++ b/src/main/java/backend/globber/membertravel/controller/GlobeController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/globes")
+@RequestMapping("api/v1/globes")
 public class GlobeController {
 
     private final GlobeService globeService;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #30 


## 📝 작업 내용
API 네이밍 변경



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 글로브 관련 엔드포인트의 기본 URL 경로를 /globes에서 /api/v1/globes로 변경했습니다.
  - 기존 클라이언트 통합은 새 경로로 요청을 업데이트해야 하며, 미갱신 시 404 등이 발생할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->