### PR TITLE
[REFACTOR] 조회 페이징 처리

### DIFF
--- a/src/main/java/backend/globber/city/controller/CityController.java
+++ b/src/main/java/backend/globber/city/controller/CityController.java
@@ -1,13 +1,15 @@
 package backend.globber.city.controller;
 
-import backend.globber.city.controller.dto.RecommendResponse;
+import backend.globber.city.controller.dto.PagedRecommendResponse;
 import backend.globber.city.controller.dto.SearchResult;
 import backend.globber.city.service.CityService;
 import backend.globber.city.service.SearchService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Max;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.converters.models.PageableAsQueryParam;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,9 +26,10 @@ public class CityController {
     private final SearchService searchService;
 
     @GetMapping("/favorites")
+    @PageableAsQueryParam
     @Operation(summary = "인기 여행지 조회", description = "인기 여행지 목록을 조회합니다.")
-    public ResponseEntity<RecommendResponse> getFavorites(@RequestParam(defaultValue = "20") @Max(500) final int limit) {
-        return ResponseEntity.ok(cityService.getTopCities(limit));
+    public ResponseEntity<PagedRecommendResponse> getFavorites(@Parameter(hidden = true) Pageable pageable) {
+        return ResponseEntity.ok(cityService.getTopCities(pageable));
     }
 
     @GetMapping

--- a/src/main/java/backend/globber/city/controller/dto/PagedRecommendResponse.java
+++ b/src/main/java/backend/globber/city/controller/dto/PagedRecommendResponse.java
@@ -1,0 +1,24 @@
+package backend.globber.city.controller.dto;
+
+import backend.globber.city.domain.City;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PagedRecommendResponse(
+        List<CityResponse> cityResponseList,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+    public static PagedRecommendResponse fromPage(final Page<City> cityPage) {
+        return new PagedRecommendResponse(
+                cityPage.getContent().stream().map(CityResponse::toResponse).toList(),
+                cityPage.getNumber(),
+                cityPage.getSize(),
+                cityPage.getTotalElements(),
+                cityPage.getTotalPages()
+        );
+    }
+}

--- a/src/main/java/backend/globber/city/repository/CityRepository.java
+++ b/src/main/java/backend/globber/city/repository/CityRepository.java
@@ -4,6 +4,7 @@ import backend.globber.city.controller.dto.CityUniqueDto;
 import backend.globber.city.controller.dto.SearchResponse;
 import backend.globber.city.domain.City;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,8 +15,7 @@ import java.util.Optional;
 
 public interface CityRepository extends JpaRepository<City, Long> {
 
-    @Query("SELECT c FROM City c")
-    List<City> findAnyCities(Pageable pageable);
+    Page<City> findAll(Pageable pageable);
 
     /**
      * pg_bigm 후보군 추출 (상위 300개)

--- a/src/main/java/backend/globber/city/service/CityService.java
+++ b/src/main/java/backend/globber/city/service/CityService.java
@@ -1,14 +1,13 @@
 package backend.globber.city.service;
 
-import backend.globber.city.controller.dto.RecommendResponse;
+import backend.globber.city.controller.dto.PagedRecommendResponse;
 import backend.globber.city.domain.City;
 import backend.globber.city.repository.CityRepository;
 import backend.globber.city.repository.cache.RankingRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,12 +19,14 @@ public class CityService {
     /**
      * 인기 도시 조회
      */
-    public RecommendResponse getTopCities(int limit) {
-        List<City> topCities = rankingRepository.getTopCities(limit);
-        if (topCities.isEmpty()) {
-            return RecommendResponse.toResponse(cityRepository.findAnyCities(PageRequest.of(0, limit)));
+    public PagedRecommendResponse getTopCities(Pageable pageable) {
+        Page<City> topCities = rankingRepository.getTopCitiesPaging(pageable);
 
+        if (topCities.isEmpty()) {
+            Page<City> cities = cityRepository.findAll(pageable);
+            return PagedRecommendResponse.fromPage(cities);
         }
-        return RecommendResponse.toResponse(topCities);
+
+        return PagedRecommendResponse.fromPage(topCities);
     }
 }

--- a/src/test/java/backend/globber/city/service/CityServiceIntegrationTest.java
+++ b/src/test/java/backend/globber/city/service/CityServiceIntegrationTest.java
@@ -1,6 +1,6 @@
 package backend.globber.city.service;
 
-import backend.globber.city.controller.dto.RecommendResponse;
+import backend.globber.city.controller.dto.PagedRecommendResponse;
 import backend.globber.city.domain.City;
 import backend.globber.city.repository.CityRepository;
 import backend.globber.city.repository.cache.RankingRepository;
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.List;
@@ -42,11 +44,13 @@ class CityServiceIntegrationTest {
         cityRepository.saveAll(cities);
         cities.forEach(rankingRepository::incrementScore);
 
-        int limit = 10;
+        Pageable pageable = PageRequest.of(0, 10);
+        PagedRecommendResponse response = cityService.getTopCities(pageable);
 
-        RecommendResponse response = cityService.getTopCities(limit);
+        assertThat(response.cityResponseList()).hasSize(10);
+        assertThat(response.totalElements()).isEqualTo(50);
+        assertThat(response.totalPages()).isEqualTo(5);
 
-        assertThat(response.cityResponseList()).hasSize(limit);
     }
 
 
@@ -58,10 +62,11 @@ class CityServiceIntegrationTest {
                 .toList();
         cityRepository.saveAll(cities);
 
-        int limit = 5;
+        Pageable pageable = PageRequest.of(0, 10);
+        PagedRecommendResponse response = cityService.getTopCities(pageable);
 
-        RecommendResponse response = cityService.getTopCities(limit);
-
-        assertThat(response.cityResponseList()).hasSize(limit);
+        assertThat(response.cityResponseList()).hasSize(10);
+        assertThat(response.totalElements()).isEqualTo(50);
+        assertThat(response.totalPages()).isEqualTo(5);
     }
 }

--- a/src/test/java/backend/globber/travelinsight/controller/TravelInsightControllerTest.java
+++ b/src/test/java/backend/globber/travelinsight/controller/TravelInsightControllerTest.java
@@ -1,8 +1,5 @@
 package backend.globber.travelinsight.controller;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
-
 import backend.globber.auth.domain.Member;
 import backend.globber.auth.domain.constant.AuthProvider;
 import backend.globber.auth.domain.constant.Role;
@@ -16,7 +13,6 @@ import backend.globber.membertravel.repository.MemberTravelRepository;
 import backend.globber.support.PostgresTestConfig;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,9 +22,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import({PostgresTestConfig.class})
-//@Transactional
 class TravelInsightControllerTest {
 
     @LocalServerPort
@@ -57,51 +57,51 @@ class TravelInsightControllerTest {
         List<City> cities = getCities();
 
         MemberTravel memberTravel = memberTravelRepository.save(MemberTravel.builder()
-            .member(member)
-            .build());
+                .member(member)
+                .build());
 
         memberTravelCityRepository.saveAll(
-            cities.stream()
-                .map(city -> MemberTravelCity.builder()
-                    .memberTravel(memberTravel)
-                    .city(city)
-                    .build())
-                .toList());
+                cities.stream()
+                        .map(city -> MemberTravelCity.builder()
+                                .memberTravel(memberTravel)
+                                .city(city)
+                                .build())
+                        .toList());
     }
 
     private static @NotNull Member getMember() {
         return Member.of(
-            "test" + System.currentTimeMillis() + "@example.com",
-            "테스트유저",
-            "password",
-            AuthProvider.KAKAO,
-            List.of(Role.ROLE_USER)
+                "test" + System.currentTimeMillis() + "@example.com",
+                "테스트유저",
+                "password",
+                AuthProvider.KAKAO,
+                List.of(Role.ROLE_USER)
         );
     }
 
     private @NotNull List<City> getCities() {
         return cityRepository.saveAll(List.of(
-            City.builder()
-                .cityName("교토")
-                .countryName("일본")
-                .countryCode("JPN")
-                .lat(35.0116)
-                .lng(135.7681)
-                .build(),
-            City.builder()
-                .cityName("도쿄")
-                .countryName("일본")
-                .countryCode("JPN")
-                .lat(35.6762)
-                .lng(139.6503)
-                .build(),
-            City.builder()
-                .cityName("방콕")
-                .countryName("태국")
-                .countryCode("THA")
-                .lat(13.7563)
-                .lng(100.5018)
-                .build()
+                City.builder()
+                        .cityName("교토")
+                        .countryName("일본")
+                        .countryCode("JPN")
+                        .lat(35.0116)
+                        .lng(135.7681)
+                        .build(),
+                City.builder()
+                        .cityName("도쿄")
+                        .countryName("일본")
+                        .countryCode("JPN")
+                        .lat(35.6762)
+                        .lng(139.6503)
+                        .build(),
+                City.builder()
+                        .cityName("방콕")
+                        .countryName("태국")
+                        .countryCode("THA")
+                        .lat(13.7563)
+                        .lng(100.5018)
+                        .build()
         ));
     }
 
@@ -109,13 +109,13 @@ class TravelInsightControllerTest {
     @DisplayName("여행 인사이트 조회 성공시 OK 반환한다")
     void aiInsight_Ok() {
         RestAssured.given().log().all()
-            .contentType(ContentType.JSON)
-            .when()
-            .get("/api/v1/travel-insights/{memberId}", member.getId())
-            .then().log().all()
-            .statusCode(200)
-            .body("status", equalTo("success"))
-            .body("data.title", notNullValue());
+                .contentType(ContentType.JSON)
+                .when()
+                .get("/api/v1/travel-insights/{memberId}", member.getId())
+                .then().log().all()
+                .statusCode(200)
+                .body("status", equalTo("success"))
+                .body("data.title", notNullValue());
     }
 
 //  @Test

--- a/src/test/java/backend/globber/travelinsight/service/TravelInsightServiceTest.java
+++ b/src/test/java/backend/globber/travelinsight/service/TravelInsightServiceTest.java
@@ -1,14 +1,5 @@
 package backend.globber.travelinsight.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-
 import backend.globber.membertravel.controller.dto.response.MemberTravelAllResponse;
 import backend.globber.membertravel.domain.MemberTravel;
 import backend.globber.membertravel.repository.MemberTravelRepository;
@@ -16,18 +7,27 @@ import backend.globber.travelinsight.client.GeminiApiClient;
 import backend.globber.travelinsight.controller.dto.response.TravelInsightResponse;
 import backend.globber.travelinsight.domain.TravelInsight;
 import backend.globber.travelinsight.repository.TravelInsightRepository;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class TravelInsightServiceTest {
@@ -69,9 +69,9 @@ class TravelInsightServiceTest {
         LocalDateTime travelUpdatedAt = insightUpdatedAt.minusHours(1); // 인사이트가 더 최신
 
         TravelInsight savedInsight = TravelInsight.builder()
-            .memberId(memberId)
-            .title("아시아 탐험가")
-            .build();
+                .memberId(memberId)
+                .title("아시아 탐험가")
+                .build();
         ReflectionTestUtils.setField(savedInsight, "updatedAt", insightUpdatedAt);
 
         MemberTravel memberTravel = createMemberTravel(travelUpdatedAt);
@@ -98,8 +98,8 @@ class TravelInsightServiceTest {
         MemberTravel memberTravel = createMemberTravel(travelUpdatedAt);
 
         TravelInsightResponse aiResponse = TravelInsightResponse.builder()
-            .title("세계 탐험가")
-            .build();
+                .title("세계 탐험가")
+                .build();
 
         given(travelInsightRepository.findByMemberId(memberId)).willReturn(Optional.empty());
         given(memberTravelRepository.findAllByMember_Id(memberId)).willReturn(List.of(memberTravel));
@@ -112,8 +112,8 @@ class TravelInsightServiceTest {
         assertThat(result.title()).isEqualTo("세계 탐험가");
         then(aiClient).should().createTitle(any(MemberTravelAllResponse.class));
         then(travelInsightRepository).should().save(argThat(insight ->
-            insight.getMemberId().equals(memberId) &&
-                insight.getTitle().equals("세계 탐험가")
+                insight.getMemberId().equals(memberId) &&
+                        insight.getTitle().equals("세계 탐험가")
         ));
     }
 
@@ -126,16 +126,16 @@ class TravelInsightServiceTest {
         LocalDateTime travelUpdatedAt = LocalDateTime.now(); // 여행 데이터가 더 최신
 
         TravelInsight savedInsight = spy(TravelInsight.builder()
-            .memberId(memberId)
-            .title("기존 탐험가")
-            .build());
+                .memberId(memberId)
+                .title("기존 탐험가")
+                .build());
         ReflectionTestUtils.setField(savedInsight, "updatedAt", insightUpdatedAt);
 
         MemberTravel memberTravel = createMemberTravel(travelUpdatedAt);
 
         TravelInsightResponse aiResponse = TravelInsightResponse.builder()
-            .title("새로운 탐험가")
-            .build();
+                .title("새로운 탐험가")
+                .build();
 
         given(travelInsightRepository.findByMemberId(memberId)).willReturn(Optional.of(savedInsight));
         given(memberTravelRepository.findAllByMember_Id(memberId)).willReturn(List.of(memberTravel));
@@ -160,11 +160,11 @@ class TravelInsightServiceTest {
 
         // ✅ 명확하게 모든 stub 설정
         given(travelInsightRepository.findByMemberId(memberId))
-            .willReturn(Optional.empty());
+                .willReturn(Optional.empty());
         given(memberTravelRepository.findAllByMember_Id(memberId))
-            .willReturn(List.of(memberTravel));
+                .willReturn(List.of(memberTravel));
         given(aiClient.createTitle(any(MemberTravelAllResponse.class)))
-            .willThrow(new RuntimeException("AI 호출 실패"));
+                .willThrow(new RuntimeException("AI 호출 실패"));
 
         // when
         TravelInsightResponse result = travelInsightService.getOrCreateInsight(memberId);
@@ -191,8 +191,8 @@ class TravelInsightServiceTest {
 
         given(travelInsightRepository.findByMemberId(memberId)).willReturn(Optional.empty());
         given(memberTravelRepository.findAllByMember_Id(memberId)).willReturn(List.of(memberTravel));
-        given(aiClient.createTitle(any(MemberTravelAllResponse.class)))
-            .willReturn(TravelInsightResponse.empty());
+        BDDMockito.BDDMyOngoingStubbing<TravelInsightResponse> travelInsightResponseBDDMyOngoingStubbing = given(aiClient.createTitle(any(MemberTravelAllResponse.class)))
+                .willReturn(TravelInsightResponse.empty());
 
         // when
         TravelInsightResponse result = travelInsightService.getOrCreateInsight(memberId);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #33 

## 📝 작업 내용
조회 페이징 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 추천/즐겨찾기 도시 조회에 페이지네이션 도입: 응답에 city 목록과 page, size, totalElements, totalPages 포함
  - API 문서에 페이지네이션 파라미터 노출로 탐색 개선
- 변경 사항
  - 기존 limit 파라미터 제거; 이제 page, size 쿼리 파라미터로 요청해야 함
  - 응답 포맷이 페이징 기반으로 변경되어 대량 데이터에서도 일관된 결과 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->