### PR TITLE
[FEATURE]  멤버 아이디 리턴 로직 추가

### DIFF
--- a/src/main/java/backend/globber/auth/controller/MemberController.java
+++ b/src/main/java/backend/globber/auth/controller/MemberController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
@@ -51,6 +52,14 @@ public class MemberController {
 
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, responseCookie.toString())
             .body(ApiResponse.success(jwtTokenResponse));
+    }
+
+    @GetMapping("/id")
+    @Operation(summary = "멤버아이디 리턴", description = "[테스트용] 토큰을 기반으로 멤버아이디를 리턴받습니다.")
+    public ResponseEntity<ApiResponse<Long>> getMemberId(
+        @RequestHeader("Authorization") String accessToken) {
+        Long memberId = tokenService.getMemberIdFromAccessToken(accessToken);
+        return ResponseEntity.ok(ApiResponse.success(memberId));
     }
 
 }

--- a/src/main/java/backend/globber/auth/service/TokenService.java
+++ b/src/main/java/backend/globber/auth/service/TokenService.java
@@ -12,4 +12,5 @@ public interface TokenService {
 
     void logout(String accessToken);
 
+    Long getMemberIdFromAccessToken(String refreshToken);
 }

--- a/src/main/java/backend/globber/auth/service/impl/TokenServiceImpl.java
+++ b/src/main/java/backend/globber/auth/service/impl/TokenServiceImpl.java
@@ -74,4 +74,18 @@ public class TokenServiceImpl implements TokenService {
         // 토큰 삭제
         refreshTokenRepository.delete(refreshTokenEntity);
     }
+
+    @Override
+    public Long getMemberIdFromAccessToken(String accessToken) {
+        // 토큰 유효여부 체크
+        if (!jwtTokenProvider.validateToken(accessToken)) {
+            throw new CustomTokenException("토큰이 유효하지 않습니다.");
+        }
+        // 사용자 체크
+        Member member = memberRepository.findByEmail(
+            jwtTokenProvider.getEmailForAccessToken(accessToken)).orElseThrow(
+            () -> new UsernameNotFoundException("해당 이메일을 가진 사용자가 존재하지 않습니다.")
+        );
+        return member.getId();
+    }
 }

--- a/src/main/java/backend/globber/auth/util/auth_filter/OauthUtil.java
+++ b/src/main/java/backend/globber/auth/util/auth_filter/OauthUtil.java
@@ -123,7 +123,14 @@ public class OauthUtil implements OAuth2UserService<OAuth2UserRequest, OAuth2Use
         response.addHeader("Authorization", accessToken);
         try {
             // 리다이렉트
-            response.sendRedirect(successRedirectUri + "?accessToken=" + accessToken + "&uuid=" + member.getUuid());
+            String redirect_uri = "";
+            if(request.getHeader("Host").equals("localhost:3000")){
+                redirect_uri = "http://localhost:3000/login/oauth/success";
+            }
+            else{
+                redirect_uri = "https://globber-fe.store/login/oauth/success";
+            }
+            response.sendRedirect(redirect_uri + "?accessToken=" + accessToken + "&uuid=" + member.getUuid());
         } catch (IOException e) {
             throw new CustomAuthException();
         }

--- a/src/main/java/backend/globber/auth/util/auth_filter/OauthUtil.java
+++ b/src/main/java/backend/globber/auth/util/auth_filter/OauthUtil.java
@@ -13,6 +13,7 @@ import backend.globber.exception.spec.CustomIOException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -123,14 +124,22 @@ public class OauthUtil implements OAuth2UserService<OAuth2UserRequest, OAuth2Use
         response.addHeader("Authorization", accessToken);
         try {
             // 리다이렉트
-            String redirect_uri = "";
-            if(request.getHeader("Host").equals("localhost:3000")){
-                redirect_uri = "http://localhost:3000/login/oauth/success";
-            }
-            else{
-                redirect_uri = "https://globber-fe.store/login/oauth/success";
-            }
-            response.sendRedirect(redirect_uri + "?accessToken=" + accessToken + "&uuid=" + member.getUuid());
+            String redirect_uri = Optional.ofNullable(request.getParameter("redirect"))
+                    .orElse("");
+
+            List<String> allowed = List.of(
+                    "http://localhost:3000",
+                    "https://globber-fe.store"
+            );
+
+            String target = allowed.stream()
+                    .filter(redirect_uri::startsWith)
+                    .findFirst()
+                    .orElseThrow(() -> new CustomAuthException("허용되지 않은 리다이렉트 URI입니다."));
+
+            String uri = target + "/login/oauth/success";
+
+            response.sendRedirect(uri + "?accessToken=" + accessToken + "&uuid=" + member.getUuid());
         } catch (IOException e) {
             throw new CustomAuthException();
         }


### PR DESCRIPTION
<!--  
    PR 제목은 다음과 같은 형식으로 작성합니다. 
 
    gitmoji [Feature/domain-issue number] title 
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
 
    PR에 사용되는 Gitmoji 가이드입니다. 
     
    feat(:sparkles:) - Introduce new features 
    fix(:bug:) - Fix a bug 
    docs(:memo:) - Add or update documentation 
    style(:art:) - Improve structure / format of the code 
    refactor(:recycle:) - Refactor code 
    perf(:zap:) - Improve performance 
    test(:white_check_mark:) - Add or update tests 
    build(:construction_worker:) - Add or update CI build system 
    chore(:gear:) - Other changes  
    revert(:rewind:) - Revert changes 
    hotfix(:ambulance:) - Critical hotfix --> 

## #️⃣ 연관된 이슈
 resolve #35


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

1. 멤버 ID를 리턴하는 로직을 추가
2. 리다이렉트 URI를 프론트쪽으로 변경

## ***📸 스크린샷 (선택)***



## ***💬 리뷰 요구사항(선택)***


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 인증된 요청에서 회원 ID를 조회하는 GET /id 엔드포인트 추가(Access Token 기반 응답).

- Bug Fixes
  - 소셜 로그인 성공 시 호스트에 따라 리다이렉트 주소를 로컬/운영으로 자동 분기해 올바른 페이지로 이동.

- Chores
  - 내부 서브모듈 참조 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->