### PR TITLE
[FEATURE] 나의 프로필 조회/수정/이미지 등록 API 개발

### DIFF
--- a/src/main/java/backend/globber/auth/domain/Member.java
+++ b/src/main/java/backend/globber/auth/domain/Member.java
@@ -3,22 +3,33 @@ package backend.globber.auth.domain;
 import backend.globber.auth.domain.constant.AuthProvider;
 import backend.globber.auth.domain.constant.Role;
 import backend.globber.auth.domain.converter.AuthProviderConverter;
-import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import io.micrometer.common.util.StringUtils;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 
 @Entity
 @Table(
-        indexes = {
-                @Index(columnList = "email", unique = true),
-        })
+    indexes = {
+        @Index(columnList = "email", unique = true),
+    })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
@@ -40,10 +51,13 @@ public class Member {
     @Column(nullable = false, unique = true, updatable = false)
     private String uuid;  // 공유 링크 식별자
     private boolean isFirstLogin;
+    @Column(length = 500)
+    private String profileImageKey;
+
 
     // -- 생성자 메서드 -- //
     private Member(String email, String name, String password, AuthProvider authProvider,
-                   List<Role> roles, String uuid) {
+        List<Role> roles, String uuid) {
         this.email = email;
         this.name = name;
         this.password = password;
@@ -54,11 +68,11 @@ public class Member {
     }
 
     public static Member of(
-            String email,
-            String name,
-            String password,
-            AuthProvider authProvider,
-            List<Role> roles
+        String email,
+        String name,
+        String password,
+        AuthProvider authProvider,
+        List<Role> roles
     ) {
         return new Member(email, name, password, authProvider, roles, UUID.randomUUID().toString());
     }
@@ -74,6 +88,18 @@ public class Member {
     public void changeFirstLogin() {
         this.isFirstLogin = false;
     }
+
+    public void changeProfileImage(String s3Key) {
+        this.profileImageKey = s3Key;
+    }
+
+    public String getProfileImageUrl(String s3BaseUrl) {
+        if (StringUtils.isEmpty(profileImageKey)) {
+            return null;
+        }
+        return s3BaseUrl + "/" + profileImageKey;
+    }
+    
     // -- 비지니스 로직 (검증, setter) -- //
 
     // -- Equals & Hash -- //

--- a/src/main/java/backend/globber/profile/controller/ProfileController.java
+++ b/src/main/java/backend/globber/profile/controller/ProfileController.java
@@ -1,0 +1,32 @@
+package backend.globber.profile.controller;
+
+import backend.globber.auth.service.TokenService;
+import backend.globber.common.dto.ApiResponse;
+import backend.globber.profile.controller.dto.response.ProfileResponse;
+import backend.globber.profile.service.ProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/profiles")
+@RequiredArgsConstructor
+public class ProfileController {
+
+    private final TokenService tokenService;
+    private final ProfileService profileService;
+
+    @GetMapping("/me")
+    @Operation(summary = "내 프로필 조회", description = "현재 로그인한 사용자의 프로필 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<ProfileResponse>> getMyProfile(
+        @RequestHeader("Authorization") String accessToken
+    ) {
+        Long memberId = tokenService.getMemberIdFromAccessToken(accessToken);
+        ProfileResponse profile = profileService.getProfile(memberId);
+        return ResponseEntity.ok(ApiResponse.success(profile));
+    }
+}

--- a/src/main/java/backend/globber/profile/controller/ProfileController.java
+++ b/src/main/java/backend/globber/profile/controller/ProfileController.java
@@ -2,6 +2,7 @@ package backend.globber.profile.controller;
 
 import backend.globber.auth.service.TokenService;
 import backend.globber.common.dto.ApiResponse;
+import backend.globber.profile.controller.dto.request.UpdateProfileImageRequest;
 import backend.globber.profile.controller.dto.request.UpdateProfileRequest;
 import backend.globber.profile.controller.dto.response.ProfileResponse;
 import backend.globber.profile.service.ProfileService;
@@ -44,5 +45,17 @@ public class ProfileController {
         ProfileResponse profile = profileService.updateProfile(memberId, request);
 
         return ResponseEntity.ok(ApiResponse.success(profile));
+    }
+
+    @PatchMapping("/me/image")
+    @Operation(summary = "프로필 이미지 수정", description = "현재 로그인한 사용자의 프로필 이미지를 수정합니다.(프론트에서 S3에 업로드 후 S3 key를 전달)")
+    public ResponseEntity<ApiResponse<ProfileResponse>> updateProfileImage(
+        @RequestHeader("Authorization") String accessToken,
+        @Valid @RequestBody UpdateProfileImageRequest request
+    ) {
+        Long memberId = tokenService.getMemberIdFromAccessToken(accessToken);
+        ProfileResponse response = profileService.updateProfileImage(memberId, request);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/backend/globber/profile/controller/ProfileController.java
+++ b/src/main/java/backend/globber/profile/controller/ProfileController.java
@@ -2,12 +2,16 @@ package backend.globber.profile.controller;
 
 import backend.globber.auth.service.TokenService;
 import backend.globber.common.dto.ApiResponse;
+import backend.globber.profile.controller.dto.request.UpdateProfileRequest;
 import backend.globber.profile.controller.dto.response.ProfileResponse;
 import backend.globber.profile.service.ProfileService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +31,18 @@ public class ProfileController {
     ) {
         Long memberId = tokenService.getMemberIdFromAccessToken(accessToken);
         ProfileResponse profile = profileService.getProfile(memberId);
+        return ResponseEntity.ok(ApiResponse.success(profile));
+    }
+
+    @PatchMapping("/me")
+    @Operation(summary = "내 프로필 수정", description = "현재 로그인 사용자의 정보(닉네임)를 수정합니다.")
+    public ResponseEntity<ApiResponse<ProfileResponse>> updateProfile(
+        @RequestHeader("Authorization") String accessToken,
+        @Valid @RequestBody UpdateProfileRequest request
+    ) {
+        Long memberId = tokenService.getMemberIdFromAccessToken(accessToken);
+        ProfileResponse profile = profileService.updateProfile(memberId, request);
+
         return ResponseEntity.ok(ApiResponse.success(profile));
     }
 }

--- a/src/main/java/backend/globber/profile/controller/dto/request/UpdateProfileImageRequest.java
+++ b/src/main/java/backend/globber/profile/controller/dto/request/UpdateProfileImageRequest.java
@@ -1,0 +1,12 @@
+package backend.globber.profile.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record UpdateProfileImageRequest(
+    @NotBlank(message = "S3 key는 필수입니다")
+    String s3Key
+) {
+
+}

--- a/src/main/java/backend/globber/profile/controller/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/backend/globber/profile/controller/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,14 @@
+package backend.globber.profile.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+public record UpdateProfileRequest(
+    @NotBlank(message = "닉네임은 필수입니다")
+    @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하여야 합니다")
+    String nickname
+) {
+
+}

--- a/src/main/java/backend/globber/profile/controller/dto/response/ProfileResponse.java
+++ b/src/main/java/backend/globber/profile/controller/dto/response/ProfileResponse.java
@@ -1,0 +1,30 @@
+package backend.globber.profile.controller.dto.response;
+
+import backend.globber.auth.domain.Member;
+import backend.globber.auth.domain.constant.AuthProvider;
+import lombok.Builder;
+
+@Builder
+public record ProfileResponse(
+    long memberId,
+    String nickname,
+    String email,
+    String profileImageUrl,
+    AuthProvider authProvider
+) {
+
+    public static ProfileResponse from(Member member, String s3BaseUrl) {
+        String imageKey = member.getProfileImageKey();
+        String fullUrl = (imageKey != null && !imageKey.isEmpty())
+            ? s3BaseUrl + "/" + imageKey
+            : null;
+
+        return ProfileResponse.builder()
+            .memberId(member.getId())
+            .nickname(member.getName())
+            .email(member.getEmail())
+            .profileImageUrl(fullUrl)
+            .authProvider(member.getAuthProvider())
+            .build();
+    }
+}

--- a/src/main/java/backend/globber/profile/controller/dto/response/ProfileResponse.java
+++ b/src/main/java/backend/globber/profile/controller/dto/response/ProfileResponse.java
@@ -13,7 +13,7 @@ public record ProfileResponse(
     AuthProvider authProvider
 ) {
 
-    public static ProfileResponse from(Member member, String s3BaseUrl) {
+    public static ProfileResponse from(final Member member, final String s3BaseUrl) {
         String imageKey = member.getProfileImageKey();
         String fullUrl = (imageKey != null && !imageKey.isEmpty())
             ? s3BaseUrl + "/" + imageKey

--- a/src/main/java/backend/globber/profile/service/ProfileService.java
+++ b/src/main/java/backend/globber/profile/service/ProfileService.java
@@ -3,7 +3,9 @@ package backend.globber.profile.service;
 import backend.globber.auth.domain.Member;
 import backend.globber.auth.repository.MemberRepository;
 import backend.globber.exception.spec.UsernameNotFoundException;
+import backend.globber.profile.controller.dto.request.UpdateProfileRequest;
 import backend.globber.profile.controller.dto.response.ProfileResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,16 @@ public class ProfileService {
     public ProfileResponse getProfile(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 멤버입니다."));
+        return ProfileResponse.from(member, s3BaseUrl);
+    }
+
+    @Transactional
+    public ProfileResponse updateProfile(Long memberId, @Valid UpdateProfileRequest request) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 멤버입니다."));
+
+        member.changeName(request.nickname());
+
         return ProfileResponse.from(member, s3BaseUrl);
     }
 }

--- a/src/main/java/backend/globber/profile/service/ProfileService.java
+++ b/src/main/java/backend/globber/profile/service/ProfileService.java
@@ -1,0 +1,27 @@
+package backend.globber.profile.service;
+
+import backend.globber.auth.domain.Member;
+import backend.globber.auth.repository.MemberRepository;
+import backend.globber.exception.spec.UsernameNotFoundException;
+import backend.globber.profile.controller.dto.response.ProfileResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileService {
+
+    private final MemberRepository memberRepository;
+
+    @Value("${aws.s3.base-url}")
+    private String s3BaseUrl;
+
+    public ProfileResponse getProfile(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 멤버입니다."));
+        return ProfileResponse.from(member, s3BaseUrl);
+    }
+}

--- a/src/main/java/backend/globber/profile/service/ProfileService.java
+++ b/src/main/java/backend/globber/profile/service/ProfileService.java
@@ -37,6 +37,7 @@ public class ProfileService {
         return ProfileResponse.from(member, s3BaseUrl);
     }
 
+    @Transactional
     public ProfileResponse updateProfileImage(Long memberId, UpdateProfileImageRequest request) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 멤버입니다."));

--- a/src/main/java/backend/globber/profile/service/ProfileService.java
+++ b/src/main/java/backend/globber/profile/service/ProfileService.java
@@ -3,9 +3,9 @@ package backend.globber.profile.service;
 import backend.globber.auth.domain.Member;
 import backend.globber.auth.repository.MemberRepository;
 import backend.globber.exception.spec.UsernameNotFoundException;
+import backend.globber.profile.controller.dto.request.UpdateProfileImageRequest;
 import backend.globber.profile.controller.dto.request.UpdateProfileRequest;
 import backend.globber.profile.controller.dto.response.ProfileResponse;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -28,11 +28,20 @@ public class ProfileService {
     }
 
     @Transactional
-    public ProfileResponse updateProfile(Long memberId, @Valid UpdateProfileRequest request) {
+    public ProfileResponse updateProfile(Long memberId, UpdateProfileRequest request) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 멤버입니다."));
 
         member.changeName(request.nickname());
+
+        return ProfileResponse.from(member, s3BaseUrl);
+    }
+
+    public ProfileResponse updateProfileImage(Long memberId, UpdateProfileImageRequest request) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 멤버입니다."));
+
+        member.changeProfileImage(request.s3Key());
 
         return ProfileResponse.from(member, s3BaseUrl);
     }

--- a/src/test/java/backend/globber/profile/service/ProfileServiceTest.java
+++ b/src/test/java/backend/globber/profile/service/ProfileServiceTest.java
@@ -1,0 +1,189 @@
+package backend.globber.profile.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import backend.globber.auth.domain.Member;
+import backend.globber.auth.domain.constant.AuthProvider;
+import backend.globber.auth.domain.constant.Role;
+import backend.globber.auth.repository.MemberRepository;
+import backend.globber.exception.spec.UsernameNotFoundException;
+import backend.globber.profile.controller.dto.request.UpdateProfileImageRequest;
+import backend.globber.profile.controller.dto.request.UpdateProfileRequest;
+import backend.globber.profile.controller.dto.response.ProfileResponse;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private ProfileService profileService;
+
+    private Member member;
+    private final String s3BaseUrl = "https://test-bucket.s3.amazonaws.com";
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(profileService, "s3BaseUrl", s3BaseUrl);
+
+        member = Member.of(
+            "test@kakao",
+            "테스트유저",
+            "password",
+            AuthProvider.KAKAO,
+            List.of(Role.ROLE_USER)
+        );
+        ReflectionTestUtils.setField(member, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("회원의 프로필을 조회한다")
+    void getProfile() {
+        // given
+        Long memberId = 1L;
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // when
+        ProfileResponse response = profileService.getProfile(memberId);
+
+        // then
+        assertThat(response.memberId()).isEqualTo(1L);
+        assertThat(response.nickname()).isEqualTo("테스트유저");
+        assertThat(response.email()).isEqualTo("test@kakao");
+        assertThat(response.profileImageUrl()).isNull();
+        assertThat(response.authProvider()).isEqualTo(AuthProvider.KAKAO);
+        verify(memberRepository, times(1)).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지가 있는 경우 full URL을 반환한다")
+    void getProfileWithImage() {
+        // given
+        Long memberId = 1L;
+        String s3Key = "profiles/1/test-image.jpg";
+        member.changeProfileImage(s3Key);
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // when
+        ProfileResponse response = profileService.getProfile(memberId);
+
+        // then
+        assertThat(response.profileImageUrl()).isEqualTo(s3BaseUrl + "/" + s3Key);
+        verify(memberRepository, times(1)).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원 조회 시 예외가 발생한다")
+    void getProfileNotFound() {
+        // given
+        Long memberId = 999L;
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> profileService.getProfile(memberId))
+            .isInstanceOf(UsernameNotFoundException.class)
+            .hasMessage("존재하지 않는 멤버입니다.");
+        verify(memberRepository, times(1)).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("회원의 닉네임을 수정한다")
+    void updateNickname() {
+        // given
+        Long memberId = 1L;
+        UpdateProfileRequest request = new UpdateProfileRequest("새닉네임");
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // when
+        ProfileResponse response = profileService.updateProfile(memberId, request);
+
+        // then
+        assertThat(response.nickname()).isEqualTo("새닉네임");
+        assertThat(member.getName()).isEqualTo("새닉네임");
+        verify(memberRepository, times(1)).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원의 닉네임 수정 시 예외가 발생한다")
+    void updateNicknameNotFound() {
+        // given
+        Long memberId = 999L;
+        UpdateProfileRequest request = new UpdateProfileRequest("새닉네임");
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> profileService.updateProfile(memberId, request))
+            .isInstanceOf(UsernameNotFoundException.class)
+            .hasMessage("존재하지 않는 멤버입니다.");
+        verify(memberRepository, times(1)).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("회원의 프로필 이미지를 수정한다")
+    void updateImage() {
+        // given
+        Long memberId = 1L;
+        String s3Key = "profiles/1/new-image.jpg";
+        UpdateProfileImageRequest request = new UpdateProfileImageRequest(s3Key);
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // when
+        ProfileResponse response = profileService.updateProfileImage(memberId, request);
+
+        // then
+        assertThat(response.profileImageUrl()).isEqualTo(s3BaseUrl + "/" + s3Key);
+        assertThat(member.getProfileImageKey()).isEqualTo(s3Key);
+        verify(memberRepository, times(1)).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("기존 프로필 이미지를 새 이미지로 덮어쓴다")
+    void updateImageOverwrite() {
+        // given
+        Long memberId = 1L;
+        String oldS3Key = "profiles/1/old-image.jpg";
+        String newS3Key = "profiles/1/new-image.jpg";
+        member.changeProfileImage(oldS3Key);
+
+        UpdateProfileImageRequest request = new UpdateProfileImageRequest(newS3Key);
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+        // when
+        ProfileResponse response = profileService.updateProfileImage(memberId, request);
+
+        // then
+        assertThat(response.profileImageUrl()).isEqualTo(s3BaseUrl + "/" + newS3Key);
+        assertThat(member.getProfileImageKey()).isEqualTo(newS3Key);
+        verify(memberRepository, times(1)).findById(memberId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원의 프로필 이미지 수정 시 예외가 발생한다")
+    void updateImageNotFound() {
+        // given
+        Long memberId = 999L;
+        UpdateProfileImageRequest request = new UpdateProfileImageRequest("profiles/999/image.jpg");
+        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> profileService.updateProfileImage(memberId, request))
+            .isInstanceOf(UsernameNotFoundException.class)
+            .hasMessage("존재하지 않는 멤버입니다.");
+        verify(memberRepository, times(1)).findById(memberId);
+    }
+}


### PR DESCRIPTION
<!--  
    PR 제목은 다음과 같은 형식으로 작성합니다. 
 
    gitmoji [Feature/domain-issue number] title 
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
 
    PR에 사용되는 Gitmoji 가이드입니다. 
     
    feat(:sparkles:) - Introduce new features 
    fix(:bug:) - Fix a bug 
    docs(:memo:) - Add or update documentation 
    style(:art:) - Improve structure / format of the code 
    refactor(:recycle:) - Refactor code 
    perf(:zap:) - Improve performance 
    test(:white_check_mark:) - Add or update tests 
    build(:construction_worker:) - Add or update CI build system 
    chore(:gear:) - Other changes  
    revert(:rewind:) - Revert changes 
    hotfix(:ambulance:) - Critical hotfix --> 

## #️⃣ 연관된 이슈
#52


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

1. 나의 프로필 조회(GET)
2. 나의 프로필 수정(PATCH)
3. 나의 프로필 이미지 업로드 (PATCH)

작업했고 프로필 이미지 업로드 flow는 이렇게 생각했습니당.
```
1. 프론트: 사용자가 이미지 선택
↓
2. 프론트: S3에 직접 업로드
PUT https://bucket.s3.amazonaws.com/profiles/123/image.jpg
↓
3. 프론트: 백엔드에 s3Key 전달
PATCH /api/v1/profiles/me/image
{ "s3Key": "profiles/123/image.jpg" }
↓
4. 백엔드: DB에 s3Key 저장
Member.profileImageKey = "profiles/123/image.jpg"
↓
5. 백엔드: full URL 만들어서 응답
profileImageUrl: "[https://bucket/](https://bucket/).../profiles/123/image.jpg"
↓
6. 프론트: 받은 URL로 이미지 표시
<img src={profileImageUrl} />
```

## ***📸 스크린샷 (선택)***



## ***💬 리뷰 요구사항(선택)***
common 패키지에 들어갈 S3Service는 따로 이슈 파서 작업하겠습니다~!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 내 프로필 조회, 닉네임 수정, 프로필 이미지 수정 API를 추가했습니다.
  - 프로필에 이미지가 설정된 경우 S3 기반의 전체 이미지 URL을 제공합니다.
  - 요청 본문 유효성 검증을 강화했습니다(닉네임 길이/공백 검증, 이미지 키 필수).
- 테스트
  - 프로필 조회/수정 시나리오 및 예외 케이스에 대한 단위 테스트를 추가했습니다.
- 기타 작업
  - 내부 구성 업데이트 및 일부 의존성/임포트 정리를 수행했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->