### PR TITLE
[HOTFIX] 로컬/개발환경에서 테스트 로그인 기능 추가

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -93,8 +93,8 @@ jobs:
             --link postgres_prod:postgres_prod \
             -p 8080:8080 \
             -e SPRING_PROFILES_ACTIVE=prod \
-            -e SPRING_REDIS_HOST=redis_prod \
-            -e SPRING_REDIS_PORT=6379 \
+            -e SPRING_DATA_REDIS_HOST=redis_prod \
+            -e SPRING_DATA_REDIS_PORT=6379 \
             -e SPRING_DATASOURCE_URL=jdbc:postgresql://postgres_prod:5432/globber \
             -e SPRING_DATASOURCE_USERNAME=globber \
             -e SPRING_DATASOURCE_PASSWORD=globber123 \

--- a/src/main/java/backend/globber/auth/controller/MemberController.java
+++ b/src/main/java/backend/globber/auth/controller/MemberController.java
@@ -3,14 +3,10 @@ package backend.globber.auth.controller;
 import backend.globber.auth.dto.response.JwtTokenResponse;
 import backend.globber.auth.service.TokenService;
 import backend.globber.auth.util.CookieProvider;
-import backend.globber.auth.util.JwtTokenProvider;
 import backend.globber.common.dto.ApiResponse;
-import backend.globber.config.TestAccountProperties;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -19,19 +15,15 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@Slf4j
 @Tag(name = "인증 API", description = "로그인, 로그아웃, 토큰 재발급 등 인증 관련 API")
 public class MemberController {
 
     private final CookieProvider cookieProvider;
     private final TokenService tokenService;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final TestAccountProperties testAccountProperties;
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
@@ -88,49 +80,4 @@ public class MemberController {
             .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
             .body(ApiResponse.success("회원탈퇴가 완료되었습니다."));
     }
-
-    @PostMapping("/dev/test-login")
-    @Operation(summary = "[개발용] 테스트 계정 로그인",
-        description = "[dev/local 환경만] 테스트 계정으로 바로 로그인하여 JWT 토큰을 발급받습니다.")
-    public ResponseEntity<ApiResponse<JwtTokenResponse>> testLogin(
-        @RequestParam String email) {
-
-        log.info("테스트 로그인 요청: {}", email);
-
-        validateTestAccount(email);
-
-        String refreshToken = jwtTokenProvider.createRefreshToken();
-        tokenService.updateRefreshToken(email, refreshToken);
-
-        List<String> roles = List.of("ROLE_USER");
-        String accessToken = jwtTokenProvider.createAccessToken(email, roles);
-
-        ResponseCookie responseCookie = cookieProvider.createRefreshCookie(refreshToken);
-
-        JwtTokenResponse response = JwtTokenResponse.toResponse(accessToken, refreshToken);
-
-        return ResponseEntity.ok()
-            .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
-            .header("Authorization", accessToken)
-            .body(ApiResponse.success(response));
-    }
-
-    private void validateTestAccount(String email) {
-        if (testAccountProperties.getAccounts() == null
-            || testAccountProperties.getAccounts().isEmpty()) {
-            log.error("설정된 테스트 계정이 없습니다.");
-            throw new IllegalArgumentException("테스트 계정이 설정되지 않았습니다.");
-        }
-
-        boolean isValidTestAccount = testAccountProperties.getAccounts().stream()
-            .anyMatch(account -> account.getEmail().equals(email));
-
-        if (!isValidTestAccount) {
-            log.warn("허용되지 않은 테스트 계정: {}", email);
-            throw new IllegalArgumentException("허용되지 않은 테스트 계정입니다: " + email);
-        }
-
-        log.debug("테스트 계정 검증 성공: {}", email);
-    }
-
 }

--- a/src/main/java/backend/globber/auth/controller/MemberController.java
+++ b/src/main/java/backend/globber/auth/controller/MemberController.java
@@ -3,10 +3,13 @@ package backend.globber.auth.controller;
 import backend.globber.auth.dto.response.JwtTokenResponse;
 import backend.globber.auth.service.TokenService;
 import backend.globber.auth.util.CookieProvider;
+import backend.globber.auth.util.JwtTokenProvider;
 import backend.globber.common.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -15,20 +18,23 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 @Tag(name = "인증 API", description = "로그인, 로그아웃, 토큰 재발급 등 인증 관련 API")
 public class MemberController {
 
     private final CookieProvider cookieProvider;
     private final TokenService tokenService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
     public ResponseEntity<ApiResponse<String>> logout(
-            @RequestHeader("Authorization") String accessToken) {
+        @RequestHeader("Authorization") String accessToken) {
         // 레디스에 있는 RefreshToken 삭제
         tokenService.logout(accessToken);
         // 쿠키 삭제
@@ -36,30 +42,30 @@ public class MemberController {
 
         // 헤더에 넣으며 쿠키 업데이트
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, responseCookie.toString())
-                .body(ApiResponse.success("로그아웃 되었습니다."));
+            .body(ApiResponse.success("로그아웃 되었습니다."));
     }
 
     @PostMapping("/reissue")
     @Operation(summary = "AccessToken 재발급", description = "AccessToken을 재발급합니다.")
     public ResponseEntity<ApiResponse<?>> reissue(
-            @RequestHeader("Authorization") String accessToken,
-            @CookieValue("RefreshToken") String refreshToken) {
+        @RequestHeader("Authorization") String accessToken,
+        @CookieValue("RefreshToken") String refreshToken) {
         // RefreshToken으로 AccessToken 재발급
         JwtTokenResponse jwtTokenResponse = tokenService.updateAccessToken(accessToken,
-                refreshToken);
+            refreshToken);
 
         // 쿠키 업데이트
         ResponseCookie responseCookie = cookieProvider.createRefreshCookie(
-                jwtTokenResponse.refreshToken());
+            jwtTokenResponse.refreshToken());
 
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, responseCookie.toString())
-                .body(ApiResponse.success(jwtTokenResponse));
+            .body(ApiResponse.success(jwtTokenResponse));
     }
 
     @GetMapping("/id")
     @Operation(summary = "멤버아이디 리턴", description = "[테스트용] 토큰을 기반으로 멤버아이디를 리턴받습니다.")
     public ResponseEntity<ApiResponse<Long>> getMemberId(
-            @RequestHeader("Authorization") String accessToken) {
+        @RequestHeader("Authorization") String accessToken) {
         Long memberId = tokenService.getMemberIdFromAccessToken(accessToken);
         return ResponseEntity.ok(ApiResponse.success(memberId));
     }
@@ -67,7 +73,7 @@ public class MemberController {
     @DeleteMapping("/withdraw")
     @Operation(summary = "회원탈퇴", description = "회원 정보를 삭제하고 로그아웃 처리합니다.")
     public ResponseEntity<ApiResponse<String>> withdraw(
-            @RequestHeader("Authorization") String accessToken) {
+        @RequestHeader("Authorization") String accessToken) {
 
         Long memberId = tokenService.getMemberIdFromAccessToken(accessToken);
 
@@ -77,8 +83,33 @@ public class MemberController {
         ResponseCookie responseCookie = cookieProvider.deleteRefreshCookie();
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
-                .body(ApiResponse.success("회원탈퇴가 완료되었습니다."));
+            .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+            .body(ApiResponse.success("회원탈퇴가 완료되었습니다."));
+    }
+
+    @PostMapping("/dev/test-login")
+    @Operation(summary = "[개발용] 테스트 계정 로그인",
+        description = "[dev/local 환경만] 테스트 계정으로 바로 로그인하여 JWT 토큰을 발급받습니다.")
+    public ResponseEntity<ApiResponse<JwtTokenResponse>> testLogin(
+        @RequestParam String email) {
+
+        log.info("테스트 로그인 요청: {}", email);
+
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+        tokenService.updateRefreshToken(email, refreshToken);
+
+        List<String> roles = List.of("ROLE_USER");
+
+        String accessToken = jwtTokenProvider.createAccessToken(email, roles);
+
+        ResponseCookie responseCookie = cookieProvider.createRefreshCookie(refreshToken);
+
+        JwtTokenResponse response = JwtTokenResponse.toResponse(accessToken, refreshToken);
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+            .header("Authorization", accessToken)
+            .body(ApiResponse.success(response));
     }
 
 }

--- a/src/main/java/backend/globber/auth/controller/MemberController.java
+++ b/src/main/java/backend/globber/auth/controller/MemberController.java
@@ -5,6 +5,7 @@ import backend.globber.auth.service.TokenService;
 import backend.globber.auth.util.CookieProvider;
 import backend.globber.auth.util.JwtTokenProvider;
 import backend.globber.common.dto.ApiResponse;
+import backend.globber.config.TestAccountProperties;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -30,6 +31,7 @@ public class MemberController {
     private final CookieProvider cookieProvider;
     private final TokenService tokenService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TestAccountProperties testAccountProperties;
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
@@ -95,11 +97,12 @@ public class MemberController {
 
         log.info("테스트 로그인 요청: {}", email);
 
+        validateTestAccount(email);
+
         String refreshToken = jwtTokenProvider.createRefreshToken();
         tokenService.updateRefreshToken(email, refreshToken);
 
         List<String> roles = List.of("ROLE_USER");
-
         String accessToken = jwtTokenProvider.createAccessToken(email, roles);
 
         ResponseCookie responseCookie = cookieProvider.createRefreshCookie(refreshToken);
@@ -110,6 +113,24 @@ public class MemberController {
             .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
             .header("Authorization", accessToken)
             .body(ApiResponse.success(response));
+    }
+
+    private void validateTestAccount(String email) {
+        if (testAccountProperties.getAccounts() == null
+            || testAccountProperties.getAccounts().isEmpty()) {
+            log.error("설정된 테스트 계정이 없습니다.");
+            throw new IllegalArgumentException("테스트 계정이 설정되지 않았습니다.");
+        }
+
+        boolean isValidTestAccount = testAccountProperties.getAccounts().stream()
+            .anyMatch(account -> account.getEmail().equals(email));
+
+        if (!isValidTestAccount) {
+            log.warn("허용되지 않은 테스트 계정: {}", email);
+            throw new IllegalArgumentException("허용되지 않은 테스트 계정입니다: " + email);
+        }
+
+        log.debug("테스트 계정 검증 성공: {}", email);
     }
 
 }

--- a/src/main/java/backend/globber/auth/controller/TestLoginController.java
+++ b/src/main/java/backend/globber/auth/controller/TestLoginController.java
@@ -1,0 +1,83 @@
+package backend.globber.auth.controller;
+
+import backend.globber.auth.dto.response.JwtTokenResponse;
+import backend.globber.auth.service.TokenService;
+import backend.globber.auth.util.CookieProvider;
+import backend.globber.auth.util.JwtTokenProvider;
+import backend.globber.common.dto.ApiResponse;
+import backend.globber.config.TestAccountProperties;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@Profile({"dev", "local"})
+@Tag(name = "테스트 API", description = "[개발용] 테스트 계정 로그인 API")
+public class TestLoginController {
+
+    private final TokenService tokenService;
+    private final CookieProvider cookieProvider;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TestAccountProperties testAccountProperties;
+
+    @PostMapping("/dev/test-login")
+    @Operation(summary = "[개발용] 테스트 계정 로그인",
+        description = "[dev/local 환경만] 설정된 테스트 계정으로 바로 로그인하여 JWT 토큰을 발급받습니다.")
+    public ResponseEntity<ApiResponse<JwtTokenResponse>> testLogin(
+        @RequestParam String email) {
+
+        log.info("테스트 로그인 요청: {}", email);
+
+        validateTestAccount(email);
+
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+        tokenService.updateRefreshToken(email, refreshToken);
+
+        List<String> roles = List.of("ROLE_USER");
+        String accessToken = jwtTokenProvider.createAccessToken(email, roles);
+
+        ResponseCookie responseCookie = cookieProvider.createRefreshCookie(refreshToken);
+
+        JwtTokenResponse response = JwtTokenResponse.toResponse(accessToken, refreshToken);
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+            .header("Authorization", accessToken)
+            .body(ApiResponse.success(response));
+    }
+
+    /**
+     * 설정된 테스트 계정인지 검증하는 메소드
+     *
+     * @param email 검증할 이메일
+     * @throws IllegalArgumentException 테스트 계정이 아닌 경우
+     */
+    private void validateTestAccount(String email) {
+        if (testAccountProperties.getAccounts() == null
+            || testAccountProperties.getAccounts().isEmpty()) {
+            log.error("설정된 테스트 계정이 없습니다.");
+            throw new IllegalArgumentException("테스트 계정이 설정되지 않았습니다.");
+        }
+
+        boolean isValidTestAccount = testAccountProperties.getAccounts().stream()
+            .anyMatch(account -> account.getEmail().equals(email));
+
+        if (!isValidTestAccount) {
+            log.warn("허용되지 않은 테스트 계정: {}", email);
+            throw new IllegalArgumentException("허용되지 않은 테스트 계정입니다: " + email);
+        }
+
+        log.debug("테스트 계정 검증 성공: {}", email);
+    }
+}

--- a/src/main/java/backend/globber/config/DevTestAccountInitializer.java
+++ b/src/main/java/backend/globber/config/DevTestAccountInitializer.java
@@ -1,0 +1,61 @@
+package backend.globber.config;
+
+import backend.globber.auth.domain.Member;
+import backend.globber.auth.domain.constant.AuthProvider;
+import backend.globber.auth.domain.constant.Role;
+import backend.globber.auth.repository.MemberRepository;
+import backend.globber.auth.service.MemberSaver;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile({"dev", "local"})
+@Slf4j
+@EnableConfigurationProperties(TestAccountProperties.class)
+public class DevTestAccountInitializer {
+
+    @Bean
+    public CommandLineRunner initTestAccounts(
+        MemberRepository memberRepository,
+        MemberSaver memberSaver,
+        TestAccountProperties testAccountProperties) {
+        return args -> {
+
+            List<TestAccountProperties.Account> testAccounts = testAccountProperties.getAccounts();
+
+            if (testAccounts == null || testAccounts.isEmpty()) {
+                log.warn("설정된 테스트 계정이 없습니다. application.yml의 app.test-accounts를 확인하세요.");
+                return;
+            }
+
+            for (TestAccountProperties.Account account : testAccounts) {
+                if (memberRepository.existsByEmail(account.getEmail())) {
+                    log.info("이미 존재함: {}", account.getEmail());
+                } else {
+                    try {
+                        Member member = Member.of(
+                            account.getEmail(),
+                            account.getNickname(),
+                            null,  // password (OAuth 사용자이므로 null)
+                            AuthProvider.KAKAO,
+                            List.of(Role.ROLE_USER),
+                            null  // uuid는 saveWithUUID에서 생성됨
+                        );
+
+                        memberSaver.saveWithUUID(member);
+                        log.info("테스트 계정 생성 완료: {} (UUID: {})", account.getEmail(), member.getUuid());
+                    } catch (Exception e) {
+                        log.error("테스트 계정 생성 실패: {} - {}", account.getEmail(), e.getMessage());
+                    }
+                }
+            }
+
+            log.info("=== 테스트 계정 자동 생성 완료 ===");
+        };
+    }
+}

--- a/src/main/java/backend/globber/config/TestAccountProperties.java
+++ b/src/main/java/backend/globber/config/TestAccountProperties.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
 
 /**
  * application-{profile}.yml의 app.test-accounts 설정을 읽어오는 클래스 - application-local.yml: 로컬 환경 테스트 계정 -

--- a/src/main/java/backend/globber/config/TestAccountProperties.java
+++ b/src/main/java/backend/globber/config/TestAccountProperties.java
@@ -11,6 +11,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * application-{profile}.yml의 app.test-accounts 설정을 읽어오는 클래스 - application-local.yml: 로컬 환경 테스트 계정 -
  * application-dev.yml: 개발 환경 테스트 계정 - application-prod.yml: 설정 없음 (프로덕션에서는 사용 안 함)
  */
+@Component
 @ConfigurationProperties(prefix = "app")
 @Getter
 @Setter

--- a/src/main/java/backend/globber/config/TestAccountProperties.java
+++ b/src/main/java/backend/globber/config/TestAccountProperties.java
@@ -1,0 +1,34 @@
+package backend.globber.config;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * application-{profile}.yml의 app.test-accounts 설정을 읽어오는 클래스 - application-local.yml: 로컬 환경 테스트 계정 -
+ * application-dev.yml: 개발 환경 테스트 계정 - application-prod.yml: 설정 없음 (프로덕션에서는 사용 안 함)
+ */
+@ConfigurationProperties(prefix = "app")
+@Getter
+@Setter
+public class TestAccountProperties {
+
+    private List<Account> testAccounts;
+
+    public List<Account> getAccounts() {
+        return testAccounts;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Account {
+
+        private String email;
+        private String nickname;
+    }
+}


### PR DESCRIPTION
<!--  
    PR 제목은 다음과 같은 형식으로 작성합니다. 
 
    gitmoji [Feature/domain-issue number] title 
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
 
    PR에 사용되는 Gitmoji 가이드입니다. 
     
    feat(:sparkles:) - Introduce new features 
    fix(:bug:) - Fix a bug 
    docs(:memo:) - Add or update documentation 
    style(:art:) - Improve structure / format of the code 
    refactor(:recycle:) - Refactor code 
    perf(:zap:) - Improve performance 
    test(:white_check_mark:) - Add or update tests 
    build(:construction_worker:) - Add or update CI build system 
    chore(:gear:) - Other changes  
    revert(:rewind:) - Revert changes 
    hotfix(:ambulance:) - Critical hotfix --> 

## #️⃣ 연관된 이슈



## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->


## ***📸 스크린샷 (선택)***



## ***💬 리뷰 요구사항(선택)***


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 개발 환경용 테스트 로그인 엔드포인트 추가
  * 애플리케이션 시작 시 테스트 계정 자동 초기화 기능 추가

* **개선 사항**
  * 회원 탈퇴 프로세스 개선으로 계정 정보 완전 삭제 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->